### PR TITLE
MailChimp Interest Group names need to be comma delimited in the subs…

### DIFF
--- a/system/postmaster/services/Mailchimp.php
+++ b/system/postmaster/services/Mailchimp.php
@@ -388,7 +388,7 @@ MailChimp helps you design email newsletters, share them on social networks, int
 		{
 			$i = count($groupings);
 
-			$groupings[$i] = array('groups' => $data['post']['groups']);
+			$groupings[$i] = array('groups' => implode(",", $data['post']['groups']));
 
 			if(isset($data['post']['group_id']))
 			{


### PR DESCRIPTION
MailChimp API v1.3 - see under merge_vars > GROUPINGS
https://apidocs.mailchimp.com/api/1.3/listsubscribe.func.php
